### PR TITLE
Stopwatch with Shopify's Polaris Theme by Will Zhang

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@shopify/polaris": "^12.9.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -1815,7 +1816,6 @@
       "version": "7.23.8",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.8.tgz",
       "integrity": "sha512-Y7KbAP984rn1VGMbGqKmBLio9V7y5Je9GvU4rQPCPinCyNfUcToxIXl06d59URp/F3LwinvODxab5N/G6qggkw==",
-      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -2672,6 +2672,46 @@
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
       "dev": true
     },
+    "node_modules/@shopify/polaris": {
+      "version": "12.9.0",
+      "resolved": "https://registry.npmjs.org/@shopify/polaris/-/polaris-12.9.0.tgz",
+      "integrity": "sha512-SSU5nEDwekYPBanp3cTtsx4u3sYWJ9MNMc6xt8iOc80izpoQCJEboZYCGrcseoSsuZ0IMf+ns2dvoYYAmPNwVw==",
+      "dependencies": {
+        "@shopify/polaris-icons": "^7.13.0",
+        "@shopify/polaris-tokens": "^8.5.0",
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "@types/react-transition-group": "^4.4.2",
+        "react-fast-compare": "^3.2.0",
+        "react-transition-group": "^4.4.2"
+      },
+      "engines": {
+        "node": "^16.17.0 || >=18.12.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@shopify/polaris-icons": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@shopify/polaris-icons/-/polaris-icons-7.13.0.tgz",
+      "integrity": "sha512-+KW2GbEDtw0WzfQlslk3Qo76lf609NvK14eBPCMCYkDP16zPfT4ydui1wRqpRPSCaW1oFOnX3A8bNpwKzOVM0Q==",
+      "engines": {
+        "node": "^16.17.0 || >=18.12.0"
+      }
+    },
+    "node_modules/@shopify/polaris-tokens": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@shopify/polaris-tokens/-/polaris-tokens-8.5.0.tgz",
+      "integrity": "sha512-GeGiNeR2lSsSKmrVI2XHkzOyD4vlYThM9qiFiKiVa+DATkM0vFJL0RAiwyhpqTmvO1+kztdD3EclL7ZzCXcDHw==",
+      "dependencies": {
+        "deepmerge": "^4.3.1"
+      },
+      "engines": {
+        "node": "^16.17.0 || >=18.12.0"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -3065,8 +3105,7 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "dev": true
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "node_modules/@types/qs": {
       "version": "6.9.7",
@@ -3084,7 +3123,6 @@
       "version": "17.0.65",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.65.tgz",
       "integrity": "sha512-oxur785xZYHvnI7TRS61dXbkIhDPnGfsXKv0cNXR/0ml4SipRIFpSMzA7HMEfOywFwJ5AOnPrXYTEiTRUQeGlQ==",
-      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -3095,7 +3133,14 @@
       "version": "18.2.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.7.tgz",
       "integrity": "sha512-GRaAEriuT4zp9N4p1i8BDBYmEyfo+xQ3yHjJU4eiK5NDa1RmUZG+unZABUTK4/Ox/M+GaHwb6Ow8rUITrtjszA==",
-      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-transition-group": {
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.10.tgz",
+      "integrity": "sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==",
       "dependencies": {
         "@types/react": "*"
       }
@@ -3109,8 +3154,7 @@
     "node_modules/@types/scheduler": {
       "version": "0.16.3",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
-      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==",
-      "dev": true
+      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ=="
     },
     "node_modules/@types/send": {
       "version": "0.17.1",
@@ -4627,8 +4671,7 @@
     "node_modules/csstype": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
-      "dev": true
+      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -4703,7 +4746,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4834,6 +4876,15 @@
       "dev": true,
       "dependencies": {
         "utila": "~0.4"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/dom-serializer": {
@@ -9094,7 +9145,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9566,6 +9616,21 @@
         "node": ">= 6"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -9693,6 +9758,11 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -9731,6 +9801,21 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",
@@ -9791,8 +9876,7 @@
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "dev": true
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.2",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@shopify/polaris": "^12.9.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,28 @@
 import React from "react";
 
 import StopWatch from "./StopWatch";
-import {Page, Text, BlockStack} from "@shopify/polaris";
+import {Page, Text, BlockStack, Link} from "@shopify/polaris";
+
+import "./style.css";
 
 export default function App() {
   return (
-    <Page>
-      <BlockStack gap="1000">
-        <Text variant="heading3xl" as="h1">
-          Stopwatch
-        </Text>
-        <StopWatch />
-      </BlockStack>
-    </Page>
+    <div id="app">
+      <Page>
+        <BlockStack gap="1000">
+          <Text variant="heading3xl" as="h1">
+            Stopwatch
+          </Text>
+          <StopWatch />
+          <Text variant="bodyLg" as="p">
+            Made by{" "}
+            <Link monochrome url="https://wizhaa.com/">
+              Will Zhang
+            </Link>{" "}
+            using Shopify's Polaris UI kit.
+          </Text>
+        </BlockStack>
+      </Page>
+    </div>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,17 @@
-import React from 'react'
+import React from "react";
+
+import StopWatch from "./StopWatch";
+import {Page, Text, BlockStack} from "@shopify/polaris";
 
 export default function App() {
-    return(
-        <div></div>
-    )
+  return (
+    <Page>
+      <BlockStack gap="1000">
+        <Text variant="heading3xl" as="h1">
+          Stopwatch
+        </Text>
+        <StopWatch />
+      </BlockStack>
+    </Page>
+  );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,26 +3,22 @@ import React from "react";
 import StopWatch from "./StopWatch";
 import {Page, Text, BlockStack, Link} from "@shopify/polaris";
 
-import "./style.css";
-
 export default function App() {
   return (
-    <div id="app">
-      <Page>
-        <BlockStack gap="1000">
-          <Text variant="heading3xl" as="h1">
-            Stopwatch
-          </Text>
-          <StopWatch />
-          <Text variant="bodyLg" as="p">
-            Made by{" "}
-            <Link monochrome url="https://wizhaa.com/">
-              Will Zhang
-            </Link>{" "}
-            using Shopify's Polaris UI kit.
-          </Text>
-        </BlockStack>
-      </Page>
-    </div>
+    <Page>
+      <BlockStack gap="1000">
+        <Text variant="heading3xl" as="h1">
+          Stopwatch
+        </Text>
+        <StopWatch />
+        <Text variant="bodyLg" as="p">
+          Made by{" "}
+          <Link monochrome url="https://wizhaa.com/">
+            Will Zhang
+          </Link>{" "}
+          using Shopify's Polaris UI kit.
+        </Text>
+      </BlockStack>
+    </Page>
   );
 }

--- a/src/Laps.tsx
+++ b/src/Laps.tsx
@@ -1,0 +1,24 @@
+import React, {useCallback, useState} from "react";
+
+import {Card, Text, BlockStack, DataTable} from "@shopify/polaris";
+
+type LapsProps = {
+  laps: Array<Array<any>>;
+};
+export default function Laps({laps}: LapsProps) {
+  return (
+    <Card>
+      <Text variant="heading2xl" as="h2">
+        Laps
+      </Text>
+      <BlockStack gap="1000">
+        <DataTable
+          columnContentTypes={["numeric", "text", "text"]}
+          headings={["Lap Number", "Lap Time", "Total Time Elapsed"]}
+          rows={laps}
+          hasZebraStripingOnData
+        />
+      </BlockStack>
+    </Card>
+  );
+}

--- a/src/StopWatch.tsx
+++ b/src/StopWatch.tsx
@@ -1,7 +1,90 @@
-import React from 'react'
+import React, {useState, useEffect} from "react";
+import {ButtonGroup, Card, Text} from "@shopify/polaris";
+
+import StopWatchButton from "./StopWatchButton";
+import Laps from "./Laps";
 
 export default function StopWatch() {
-    return(
-        <div></div>
-    )
+  // states to store if stopwatch is running and all elapsed time & time per lap.
+  const [running, setRunning] = useState(false);
+  const [elapsedTime, setElapsedTime] = useState(0);
+  const [lapTime, setLapTime] = useState(0);
+  const [laps, setLaps] = useState([]);
+
+  // format the time to hh:mm:ss:ms
+  const formatTime = (ms: number) => {
+    const hh = Math.floor(ms / (60 * 60 * 1000));
+    const mm = Math.floor((ms % (60 * 60 * 1000)) / (60 * 1000));
+    const ss = Math.floor((ms % (60 * 1000)) / 1000);
+    const _ms = ms % 1000;
+    const pad = (num: number, length = 2) => {
+      return num.toString().padStart(length, "0");
+    };
+
+    return `${pad(hh)}:${pad(mm)}:${pad(ss)}:${pad(_ms)}`;
+  };
+
+  const handleStartTimer = () => {
+    setRunning(true);
+  };
+
+  const handlePauseTimer = () => {
+    setRunning(false);
+  };
+
+  const handleResetTimer = () => {
+    setRunning(false);
+    setElapsedTime(0);
+    setLaps([]);
+  };
+
+  const lap = () => {
+    const lapNo = laps.length;
+    setLaps([...laps, [lapNo, formatTime(lapTime), formatTime(elapsedTime)]]);
+    setLapTime(0);
+  };
+
+  // Update the stopwatch & lap time
+  useEffect(() => {
+    let interval: any;
+    let lapInterval: any;
+    if (running) {
+      interval = setInterval(() => setElapsedTime((time) => time + 10), 10);
+      lapInterval = setInterval(
+        () => setLapTime((elapsedTime) => elapsedTime + 10),
+        10
+      );
+    }
+    return () => {
+      clearInterval(interval);
+      clearInterval(lapInterval);
+    };
+  }, [running, elapsedTime]);
+
+  return (
+    <>
+      <Card>
+        <Text variant="heading3xl" as="h2">
+          {formatTime(elapsedTime)}
+        </Text>
+        <ButtonGroup gap="loose">
+          {!running ? (
+            <StopWatchButton onClick={handleStartTimer} variant="primary">
+              Start
+            </StopWatchButton>
+          ) : (
+            <StopWatchButton onClick={handlePauseTimer} variant="primary">
+              Pause
+            </StopWatchButton>
+          )}
+          {!running ? (
+            <StopWatchButton onClick={handleResetTimer}>Reset</StopWatchButton>
+          ) : (
+            <StopWatchButton onClick={lap}>Lap</StopWatchButton>
+          )}
+        </ButtonGroup>
+      </Card>
+      <Laps laps={laps}></Laps>
+    </>
+  );
 }

--- a/src/StopWatch.tsx
+++ b/src/StopWatch.tsx
@@ -12,16 +12,16 @@ export default function StopWatch() {
   const [laps, setLaps] = useState([]);
 
   // format the time to hh:mm:ss:ms
-  const formatTime = (ms: number) => {
-    const hh = Math.floor(ms / (60 * 60 * 1000));
-    const mm = Math.floor((ms % (60 * 60 * 1000)) / (60 * 1000));
-    const ss = Math.floor((ms % (60 * 1000)) / 1000);
-    const _ms = ms % 1000;
+  const formatTime = (seconds: number) => {
+    const hh = Math.floor(seconds / (60 * 60 * 1000));
+    const mm = Math.floor((seconds % (60 * 60 * 1000)) / (60 * 1000));
+    const ss = Math.floor((seconds % (60 * 1000)) / 1000);
+
     const pad = (num: number, length = 2) => {
       return num.toString().padStart(length, "0");
     };
 
-    return `${pad(hh)}:${pad(mm)}:${pad(ss)}:${pad(_ms)}`;
+    return `${pad(hh)}:${pad(mm)}:${pad(ss)}`;
   };
 
   const handleStartTimer = () => {
@@ -49,11 +49,14 @@ export default function StopWatch() {
     let interval: any;
     let lapInterval: any;
     if (running) {
-      interval = setInterval(() => setElapsedTime((time) => time + 10), 10);
+      interval = setInterval(() => setElapsedTime((time) => time + 1), 1000);
       lapInterval = setInterval(
-        () => setLapTime((elapsedTime) => elapsedTime + 10),
-        10
+        () => setLapTime((elapsedTime) => elapsedTime + 1),
+        1000
       );
+    } else {
+      clearInterval(interval);
+      clearInterval(lapInterval);
     }
     return () => {
       clearInterval(interval);

--- a/src/StopWatch.tsx
+++ b/src/StopWatch.tsx
@@ -13,9 +13,9 @@ export default function StopWatch() {
 
   // format the time to hh:mm:ss:ms
   const formatTime = (seconds: number) => {
-    const hh = Math.floor(seconds / (60 * 60 * 1000));
-    const mm = Math.floor((seconds % (60 * 60 * 1000)) / (60 * 1000));
-    const ss = Math.floor((seconds % (60 * 1000)) / 1000);
+    const hh = Math.floor(seconds / 3600);
+    const mm = Math.floor(hh / 60);
+    const ss = Math.floor(seconds % 60);
 
     const pad = (num: number, length = 2) => {
       return num.toString().padStart(length, "0");

--- a/src/StopWatchButton.tsx
+++ b/src/StopWatchButton.tsx
@@ -1,7 +1,20 @@
-import React from 'react'
+import React from "react";
+import {Button} from "@shopify/polaris";
 
-export default function StopWatchButton() {
-    return(
-        <div></div>
-    )
+type StopWatchBUttonProps = {
+  children: string;
+  onClick: () => void;
+  variant?: "primary" | "secondary";
+};
+
+export default function StopWatchButton({
+  children,
+  onClick,
+  variant,
+}: StopWatchBUttonProps) {
+  return (
+    <Button onClick={onClick} variant={variant}>
+      {children}
+    </Button>
+  );
 }

--- a/src/StopWatchButton.tsx
+++ b/src/StopWatchButton.tsx
@@ -13,7 +13,7 @@ export default function StopWatchButton({
   variant,
 }: StopWatchBUttonProps) {
   return (
-    <Button onClick={onClick} variant={variant}>
+    <Button onClick={onClick} variant={variant} size="large">
       {children}
     </Button>
   );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,15 @@
-import React from 'react';
-import { createRoot } from 'react-dom/client';
-import App from './App';
+import React from "react";
+import {createRoot} from "react-dom/client";
+import App from "./App";
 
-const container = document.getElementById('root');
+import "@shopify/polaris/build/esm/styles.css";
+import {AppProvider} from "@shopify/polaris";
+import translations from "@shopify/polaris/locales/en.json";
+
+const container = document.getElementById("root");
 const root = createRoot(container);
-root.render(<App />);
+root.render(
+  <AppProvider i18n={translations}>
+    <App />
+  </AppProvider>
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "jsx": "react",
     "allowJs": true,
     "moduleResolution": "node",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
# Summary 

Implemented stopwatch with start, pause, reset, and lap functionality. 
- [x] Stopwatch starts counting when Start button is clicked 
- [x] Stops counting with Stop button is clicked
- [x] Resets to zero when Reset button is clicked 
- [x] Records and displays laps when Lap button is clicked


# Testing 

https://github.com/Shopify/eng-intern-assessment-react/assets/46132945/2d43d13a-99f1-4838-934f-b2a6b2ff70b4

# Concerns & Breaking Changes
Originally, did have HH:MM:SS:MS time format but looked at the Jest unit tests and saw that it was checking for HH:MM:SS format. Testing with Jest does not work with Polaris components - also requires us to install `jsdom` dependencies. 

To pass test cases, I have another branch - linked [here] with no Polaris but just raw React and CSS to pass 3/5 of the test cases. There still seemed to be some error passing the displaying laps times and pausing the stopwatch test cases (3, 4) despite being fully functional through the site itself. 




